### PR TITLE
Support rescue splat syntax for improved exception variable type inference

### DIFF
--- a/sig/test/type_construction_test.rbs
+++ b/sig/test/type_construction_test.rbs
@@ -295,6 +295,8 @@ class TypeConstructionTest < Minitest::Test
 
   def test_rescue_binding_typing: () -> untyped
 
+  def test_rescue_splat_binding_typing: () -> untyped
+
   def test_string_or_true_false: () -> untyped
 
   def test_type_case_case_when: () -> untyped


### PR DESCRIPTION
This commit adds support for `rescue *ERRORS => e` syntax in type construction, enabling proper Union type inference for exception variables.

Previously, splat operators in rescue clauses were treated as unsupported syntax, causing exception variables to have `untyped` instead of the expected Union type derived from the splatted array elements.

Example:

```ruby
ERRORS = [FooError, BarError]
begin
  # some operation
rescue *ERRORS => e
  # e now correctly has type (FooError | BarError | nil)
end
```