### PR TITLE
 feat: Add built-in support for Rakefiles

### DIFF
--- a/lib/steep/project/dsl.rb
+++ b/lib/steep/project/dsl.rb
@@ -119,15 +119,15 @@ module Steep
         end
 
         def source_pattern
-          Pattern.new(patterns: sources, ignores: ignored_sources, ext: ".rb")
+          Pattern.new(patterns: sources, ignores: ignored_sources, extensions: [".rb", ".rake"])
         end
 
         def signature_pattern
-          Pattern.new(patterns: signatures, ignores: ignored_signatures, ext: ".rbs")
+          Pattern.new(patterns: signatures, ignores: ignored_signatures, extensions: [".rbs"])
         end
 
         def inline_source_pattern
-          Pattern.new(patterns: inline_sources, ignores: ignored_inline_sources, ext: ".rb")
+          Pattern.new(patterns: inline_sources, ignores: ignored_inline_sources, extensions: [".rb"])
         end
       end
 

--- a/lib/steep/project/pattern.rb
+++ b/lib/steep/project/pattern.rb
@@ -6,11 +6,21 @@ module Steep
       attr_reader :prefixes
       attr_reader :ignore_prefixes
       attr_reader :ext
+      attr_reader :extensions
 
-      def initialize(patterns:, ignores: [], ext:)
+      def initialize(patterns:, ignores: [], ext: nil, extensions: [])
         @patterns = patterns
         @ignores = ignores
-        @ext = ext
+
+        if !extensions.empty?
+          @extensions = extensions
+          @ext = extensions.first #: String
+        elsif ext
+          @extensions = [ext]
+          @ext = ext
+        else
+          raise ArgumentError, "Either ext or extensions must be provided"
+        end
 
         @prefixes = patterns.map do |pat|
           if pat == "." || pat == "./"
@@ -48,7 +58,9 @@ module Steep
         string = path.to_s
 
         patterns.any? {|pat| File.fnmatch(pat, string, File::FNM_PATHNAME) } ||
-          prefixes.any? {|prefix| File.fnmatch("#{prefix}**/*#{ext}", string, File::FNM_PATHNAME) }
+          prefixes.any? {|prefix|
+            extensions.any? {|ext| File.fnmatch("#{prefix}**/*#{ext}", string, File::FNM_PATHNAME) }
+          }
       end
 
       def empty?

--- a/lib/steep/services/file_loader.rb
+++ b/lib/steep/services/file_loader.rb
@@ -44,7 +44,9 @@ module Steep
                   yield relative_path
                 end
               else
-                files = Pathname.glob("#{absolute_path}/**/*#{pattern.ext}")
+                files = pattern.extensions.flat_map do |ext|
+                  Pathname.glob("#{absolute_path}/**/*#{ext}")
+                end
 
                 files.sort.each do |source_path|
                   if source_path.file?

--- a/lib/steep/services/type_check_service.rb
+++ b/lib/steep/services/type_check_service.rb
@@ -340,9 +340,18 @@ module Steep
           module_type = annotations.self_type
           instance_type = annotations.self_type
         else
-          module_name = AST::Builtin::Object.module_name
-          module_type = AST::Builtin::Object.module_type
-          instance_type = AST::Builtin::Object.instance_type
+          if source.path.extname == ".rake"
+            # For .rake files, the top-level self is (Object & Rake::DSL)
+            object_type = AST::Builtin::Object.instance_type
+            rake_dsl_type = AST::Types::Name::Instance.new(name: RBS::TypeName.parse("::Rake::DSL"), args: [])
+            instance_type = AST::Types::Intersection.new(types: [object_type, rake_dsl_type])
+            module_name = AST::Builtin::Object.module_name
+            module_type = AST::Builtin::Object.module_type
+          else
+            module_name = AST::Builtin::Object.module_name
+            module_type = AST::Builtin::Object.module_type
+            instance_type = AST::Builtin::Object.instance_type
+          end
         end
 
         definition = subtyping.factory.definition_builder.build_instance(module_name)

--- a/rbs_collection.steep.yaml
+++ b/rbs_collection.steep.yaml
@@ -39,3 +39,4 @@ gems:
   - name: digest
   - name: uri
   - name: socket
+  - name: rake

--- a/sig/steep/project/pattern.rbs
+++ b/sig/steep/project/pattern.rbs
@@ -3,7 +3,7 @@ module Steep
     # `Pattern` class represents a pair of *positive* and *negative* patterns that may match with a pathname
     #
     # ```rb
-    # pat = Pattern.new(patterns: ["app/models"], ignores: ["app/models/account.rb"], ext: ".rbs")
+    # pat = Pattern.new(patterns: ["app/models"], ignores: ["app/models/account.rb"], extensions: [".rbs"])
     #
     # pat =~ "app/models/group.rb"    # => true
     # pat =~ "app/models/account.rb"  # => false
@@ -27,9 +27,13 @@ module Steep
       # Negative *dir name* pattern constructed from `#ignores`, which is tested with `start_with?`
       attr_reader ignore_prefixes: Array[String]
 
+      %a{deprecated}
       attr_reader ext: String
 
-      def initialize: (patterns: Array[String], ext: String, ?ignores: Array[String]) -> void
+      # Array of file extensions to match
+      attr_reader extensions: Array[String]
+
+      def initialize: (patterns: Array[String], ?ext: String?, ?extensions: Array[String], ?ignores: Array[String]) -> void
 
       # Returns `true` if given path matches to *positive* pattern, but doesn't match to *negative* pattern
       #

--- a/sig/test/pattern_test.rbs
+++ b/sig/test/pattern_test.rbs
@@ -6,4 +6,8 @@ class PatternTest < Minitest::Test
   def test_pattern: () -> untyped
 
   def test_pattern_with_glob: () -> untyped
+
+  def test_pattern_with_multiple_extensions: () -> untyped
+
+  def test_pattern_backward_compatibility_with_ext: () -> untyped
 end

--- a/sig/test/project_test.rbs
+++ b/sig/test/project_test.rbs
@@ -8,4 +8,6 @@ class ProjectTest < Minitest::Test
   include Steep
 
   def dirs: () -> untyped
+
+  def test_source_pattern_includes_rake_files: () -> untyped
 end

--- a/smoke/rake/Steepfile
+++ b/smoke/rake/Steepfile
@@ -1,0 +1,4 @@
+target :lib do
+  check "."
+  signature "."
+end

--- a/smoke/rake/rake_dsl.rbs
+++ b/smoke/rake/rake_dsl.rbs
@@ -1,0 +1,7 @@
+module Rake
+  module DSL
+    def namespace: (?untyped name) ?{ () -> void } -> void
+    def desc: (String description) -> void
+    def task: (*untyped args) ?{ (untyped, untyped) -> void } -> void
+  end
+end

--- a/smoke/rake/sample.rake
+++ b/smoke/rake/sample.rake
@@ -1,0 +1,20 @@
+# This is a sample .rake file to test Rake::DSL top-level context
+
+desc "Run tests"
+task :test do
+  puts "Running tests..."
+end
+
+desc "Build the project"
+task :build => :test do
+  puts "Building project..."
+end
+
+# Test that Rake DSL methods are available at top-level
+namespace :sample do
+  desc "Sample task"
+  task :hello do
+    puts "Hello from rake task!"
+    1 + ""
+  end
+end

--- a/smoke/rake/test_expectations.yml
+++ b/smoke/rake/test_expectations.yml
@@ -1,0 +1,19 @@
+---
+- file: sample.rake
+  diagnostics:
+  - range:
+      start:
+        line: 18
+        character: 4
+      end:
+        line: 18
+        character: 10
+    severity: ERROR
+    message: |-
+      Cannot find compatible overloading of method `+` of type `::Integer`
+      Method types:
+        def +: (::Integer) -> ::Integer
+             | (::Float) -> ::Float
+             | (::Rational) -> ::Rational
+             | (::Complex) -> ::Complex
+    code: Ruby::UnresolvedOverloading

--- a/test/file_loader_test.rb
+++ b/test/file_loader_test.rb
@@ -23,7 +23,7 @@ class FileLoaderTest < Minitest::Test
       (current_dir + "test/foo_test.rb").write("")
       (current_dir + "Rakefile").write("")
 
-      pat = Pattern.new(patterns: ["lib", "test"], ext: ".rb")
+      pat = Pattern.new(patterns: ["lib", "test"], extensions: [".rb"])
 
       assert_equal [Pathname("lib/foo.rb"), Pathname("test/foo_test.rb")], loader.each_path_in_patterns(pat).to_a
       assert_equal [Pathname("lib/foo.rb")], loader.each_path_in_patterns(pat, ["lib"]).to_a
@@ -43,7 +43,7 @@ class FileLoaderTest < Minitest::Test
       (current_dir + "lib/foo/parser.rb").write("")
       (current_dir + "lib/foo/bar/index.html.erb").write("")
 
-      pat = Pattern.new(patterns: ["lib/*/bar"], ext: ".rb")
+      pat = Pattern.new(patterns: ["lib/*/bar"], extensions: [".rb"])
 
       assert_equal [Pathname("lib/foo/bar/baz.rb")], loader.each_path_in_patterns(pat, []).to_a
     end
@@ -58,7 +58,7 @@ class FileLoaderTest < Minitest::Test
       (current_dir + "lib/foo/parser.rb").write("")
       (current_dir + "lib/foo/bar/index.html.erb").write("")
 
-      pat = Pattern.new(patterns: ["lib/*/bar/baz.rb"], ext: ".rb")
+      pat = Pattern.new(patterns: ["lib/*/bar/baz.rb"], extensions: [".rb"])
 
       assert_equal [Pathname("lib/foo/bar/baz.rb")], loader.each_path_in_patterns(pat, []).to_a
     end

--- a/test/pattern_test.rb
+++ b/test/pattern_test.rb
@@ -6,7 +6,7 @@ class PatternTest < Minitest::Test
   def test_pattern
     pattern = Project::Pattern.new(
       patterns: ["app/models", "app/controllers/**/*.rb"],
-      ext: ".rb"
+      extensions: [".rb"]
     )
 
     assert_operator pattern, :=~, "app/models/account.rb"
@@ -17,10 +17,31 @@ class PatternTest < Minitest::Test
   def test_pattern_with_glob
     pattern = Project::Pattern.new(
       patterns: ["app/models/*/bar"],
-      ext: ".rb"
+      extensions: [".rb"]
     )
 
     assert_operator pattern, :=~, "app/models/foo/bar/baz.rb"
     assert_operator pattern, :=~, "app/models/foo/bar/baz/qux.rb"
+  end
+
+  def test_pattern_with_multiple_extensions
+    pattern = Project::Pattern.new(
+      patterns: ["app/models"],
+      extensions: [".rb", ".rake"]
+    )
+
+    assert_operator pattern, :=~, "app/models/account.rb"
+    assert_operator pattern, :=~, "app/models/account.rake"
+    refute_operator pattern, :=~, "app/models/account.py"
+  end
+
+  def test_pattern_backward_compatibility_with_ext
+    pattern = Project::Pattern.new(
+      patterns: ["app/models"],
+      ext: ".rb"
+    )
+
+    assert_operator pattern, :=~, "app/models/account.rb"
+    refute_operator pattern, :=~, "app/models/account.rake"
   end
 end

--- a/test/project_test.rb
+++ b/test/project_test.rb
@@ -9,4 +9,12 @@ class ProjectTest < Minitest::Test
   def dirs
     @dirs ||= []
   end
+
+  def test_source_pattern_includes_rake_files
+    pattern = Project::Pattern.new(patterns: ["lib"], extensions: [".rb", ".rake"])
+    
+    assert pattern =~ "lib/tasks/sample.rake"
+    assert pattern =~ "lib/models/user.rb"
+    refute pattern =~ "lib/assets/app.js"
+  end
 end


### PR DESCRIPTION
We use Rake in our work and want to perform type checking on Rakefiles, similar to how we check standard Ruby files. However, type-checking Rakefiles with the current Steep setup presents several challenges.

First, Rakefiles are not discovered by default. A `check '.'` directive in the `Steepfile` does not include files with a `.rake` extension, forcing users to explicitly add `check '*.rake'`.

Second, Rake's DSL methods like `namespace` and `task` result in `NoMethodError`s. While a Rakefile's top-level `self` has access to `Rake::DSL` methods, Steep only recognizes it as `main` (an instance of `Object`), leading to incorrect type analysis.

To work around these issues, users currently need to:
1. Explicitly list Rakefile patterns (e.g., `'*.rake'`) in the `Steepfile`.
2. Add a type annotation or ignore comments in each Rakefile:
```rb
 namespace :foo do # steep:ignore NoMethod
   # @type self: Object & Rake::DSL
   task bar: :environment do |name, _args|
     # do something
   end
 end
```

This commit introduces built-in support for Rakefiles by eliminating the need for such manual configuration.
It treats `.rake` files as standard Ruby files by default and automatically types the top-level `self` in Rakefiles as `Object & Rake::DSL`.